### PR TITLE
Fix: max value for food and water not applied

### DIFF
--- a/Brinicle_Patch.cs
+++ b/Brinicle_Patch.cs
@@ -88,7 +88,7 @@ namespace Tweaks_Fixes
                     __instance.UpdatePlayerDamage(currentTime);
                     float fadeAmount = Mathf.InverseLerp(__instance.timeStateCanged, __instance.timeNextState, currentTime);
                     foreach (Renderer fadeRenderer in __instance.fadeRenderers)
-                        fadeRenderer.fadeAmount = fadeAmount;
+                        fadeRenderer.SetFadeAmount(fadeAmount);
                     if (fadeAmount != 1f)
                         break;
                     if (__instance.breakAfterFadeOut && __instance.fxController != null)

--- a/ConfigMenu.cs
+++ b/ConfigMenu.cs
@@ -46,6 +46,8 @@ namespace Tweaks_Fixes
         public static ConfigEntry<EmptyVehiclesCanBeAttacked> emptyVehiclesCanBeAttacked;
         //public static ConfigEntry<int> hungerUpdateInterval;
         public static ConfigEntry<bool> newHungerSystem;
+        public static ConfigEntry<int> maxFood;
+        public static ConfigEntry<int> maxWater;
         public static ConfigEntry<float> fishFoodWaterRatio;
         public static ConfigEntry<EatingRawFish> eatRawFish;
         public static ConfigEntry<bool> cantEatUnderwater;
@@ -120,6 +122,8 @@ namespace Tweaks_Fixes
             emptyVehiclesCanBeAttacked = Main.configMenu.Bind("", "Unmanned vehicles can be attacked", EmptyVehiclesCanBeAttacked.Vanilla, "By default unmanned seamoth or prawn suit can be attacked but cyclops can not.");
             //hungerUpdateInterval = Main.configMenu.Bind("", "Hunger update interval", 10, "Time in seconds it takes your hunger and thirst to update.");
             newHungerSystem = Main.configMenu.Bind("", "New hunger system", false, "You do not regenerate health when you are full. When you sprint you get hungry and thirsty twice as fast. You don't lose health when your food or water value is 0. Your food and water values can go as low as -100. When your food or water value is below 0 your movement speed will be reduced proportionally to that value. When either your food or water value is -100 your movement speed will be reduced by 50% and you will start taking hunger damage. Your max food and max water value is 200. The higher your food value above 100 is the less food you get when eating: when your food value is 110 you lose 10% of food, when it is 190 you lose 90%.");
+            maxFood = Main.configMenu.Bind("", "Max player food value", 200, "Maximum player food value. Fixed at 200 for New Hunger System.");
+            maxWater = Main.configMenu.Bind("", "Max player water value", 100, "Maximum player water value. Fixed at 200 for New Hunger System.");
             fishFoodWaterRatio = Main.configMenu.Bind("", "Fish water/food value ratio", 0f, "Fish's water value will be proportional to its food value if this is more than 0. If this is 0.1 then water value will be 10% of food value. If this is 0.9 then water value will be 90% of food value. Game has to be reloaded after changing this.");
             eatRawFish = Main.configMenu.Bind("", "Eating raw fish", EatingRawFish.Vanilla, "This changes amount of food you get by eating raw fish. Harmless: it is a random number between 0 and fish's food value. Risky: it is a random number between fish's negative food value and fish's food value. Harmful: it is a random number between fish's negative food value and 0.");
             cantEatUnderwater = Main.configMenu.Bind("", "Can not eat underwater", false, "You will not be able to eat or drink when swimming underwater if this is on.");
@@ -152,7 +156,6 @@ namespace Tweaks_Fixes
             foodLossMult = Main.configMenu.Bind("", "Food loss multiplier", 1f, "Food value you lose when your hunger updates will be multiplied by this.");
             waterLossMult = Main.configMenu.Bind("", "Water loss multiplier", 1f, "Water value you lose when your hunger updates will be multiplied by this.");
             foodWaterHealThreshold = Main.configMenu.Bind("", "Food heal threshold", 150, "Your health regenerates when sum of your food and water values is greater than this");
-
 
             transferAllItemsButton = Main.configMenu.Bind("", "Move all items button", KeyCode.None, "When you have a container open, press this button on a controller to move all items. If you are using a keyboard, you have to hold down this key and click an item.");
             transferSameItemsButton = Main.configMenu.Bind("", "Move same items button", KeyCode.None, "When you have a container open, press this button on a controller to move all items of the same type. If you are using a keyboard, you have to hold down this key and click an item.");

--- a/Main.cs
+++ b/Main.cs
@@ -24,7 +24,7 @@ namespace Tweaks_Fixes
         public const string
             MODNAME = "Tweaks and Fixes",
             GUID = "qqqbbb.subnauticaBZ.tweaksAndFixes",
-            VERSION = "2.15.0";
+            VERSION = "2.16.0";
         public static Survival survival;
         public static float oceanLevel;
         public static System.Random rndm = new System.Random();

--- a/OptionsMenu.cs
+++ b/OptionsMenu.cs
@@ -36,6 +36,8 @@ namespace Tweaks_Fixes
             ModSliderOption crushDamageProgressionSlider = ConfigMenu.crushDamageProgression.ToModSliderOption(0f, 1f, .01f, "{0:0.0#}");
 
             //ModSliderOption hungerUpdateIntervalSlider = ConfigMenu.hungerUpdateInterval.ToModSliderOption(1, 100, 1);
+            ModSliderOption maxFoodSlider = ConfigMenu.maxFood.ToModSliderOption(100, 300, 1);
+            ModSliderOption maxWaterSlider = ConfigMenu.maxWater.ToModSliderOption(100, 300, 1);
             ModSliderOption fishFoodWaterRatioSlider = ConfigMenu.fishFoodWaterRatio.ToModSliderOption(0f, 1f, .01f, "{0:0.0#}");
             ModSliderOption foodDecayRateSlider = ConfigMenu.foodDecayRateMult.ToModSliderOption(0f, 3f, .1f, "{0:0.#}");
             ModSliderOption fruitGrowTimeSlider = ConfigMenu.fruitGrowTime.ToModSliderOption(0, 30, 1);
@@ -91,6 +93,8 @@ namespace Tweaks_Fixes
             AddItem(baseHullStrengthSlider);
 
             AddItem(ConfigMenu.newHungerSystem.ToModToggleOption());
+            AddItem(maxFoodSlider);
+            AddItem(maxWaterSlider);
             AddItem(ConfigMenu.eatRawFish.ToModChoiceOption());
             AddItem(ConfigMenu.cantEatUnderwater.ToModToggleOption());
             AddItem(fishFoodWaterRatioSlider);

--- a/Survival_.cs
+++ b/Survival_.cs
@@ -326,8 +326,8 @@ namespace Tweaks_Fixes
                 if (eatable.maxCharges > 0)
                     eatable.ConsumeCharge();
 
-                Mathf.Clamp(__instance.water, playerMinFood, playerMaxWater);
-                Mathf.Clamp(__instance.food, playerMinFood, playerMaxFood);
+                __instance.water = Mathf.Clamp(__instance.water, playerMinFood, playerMaxWater);
+                __instance.food = Mathf.Clamp(__instance.food, playerMinFood, playerMaxFood);
 
                 int warn = ConfigMenu.newHungerSystem.Value ? 0 : 20;
                 if (!__instance.InConversation())

--- a/Survival_.cs
+++ b/Survival_.cs
@@ -184,8 +184,8 @@ namespace Tweaks_Fixes
                 float healthValue = eatable.GetHealthValue();
                 float coldMeterValue = eatable.GetColdMeterValue();
                 int playerMinFood = ConfigMenu.newHungerSystem.Value ? -100 : 0;
-                float playerMaxWater = ConfigMenu.newHungerSystem.Value ? 200f : 100f;
-                float playerMaxFood = 200f;
+                float playerMaxWater = ConfigMenu.newHungerSystem.Value ? 200f : (float)ConfigMenu.maxWater.Value;
+                float playerMaxFood = ConfigMenu.newHungerSystem.Value ? 200f : (float)ConfigMenu.maxFood.Value;
                 int minFood = food;
                 int maxFood = food;
                 int minWater = water;


### PR DESCRIPTION
With this mod enabled. food and water is currently added indefinitely. The following value clamp is actually not applied:
https://github.com/qqqbbb/Tweaks-and-Fixes-BZ/blob/ecc88d5e69f2b2d334371d5f43cd165c14568a73/Survival_.cs#L329-L330

This PR fixes the issue and adds an option to set the maximum values for food and water, without New Hunger System enabled. Defaults are 200 food and 100 water (same as intended hardcoded values).

To get it to build I also had to fix a property error.

Tested release: [Tweaks and fixes-196-2-16-0.zip](https://github.com/user-attachments/files/19031419/Tweaks.and.fixes-196-2-16-0.zip)
